### PR TITLE
Implement OrchestrationEventReceiver

### DIFF
--- a/src/LLL.DurableTask.Worker/Orchestrations/MethodTaskOrchestration.cs
+++ b/src/LLL.DurableTask.Worker/Orchestrations/MethodTaskOrchestration.cs
@@ -1,14 +1,19 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using DurableTask.Core;
-using Newtonsoft.Json;
+using DurableTask.Core.Serializing;
+using LLL.DurableTask.Core.Serializing;
 
 namespace LLL.DurableTask.Worker.Orchestrations
 {
     public class MethodTaskOrchestration : TaskOrchestration
     {
         private readonly MethodInfo _methodInfo;
+        private readonly DataConverter _dataConverter;
+        private readonly OrchestrationEventReceiver _eventReceiver;
 
         public MethodTaskOrchestration(
             object instance,
@@ -16,27 +21,55 @@ namespace LLL.DurableTask.Worker.Orchestrations
         {
             Instance = instance;
             _methodInfo = methodInfo;
+            _dataConverter = new UntypedJsonDataConverter();
+            _eventReceiver = new OrchestrationEventReceiver(_dataConverter);
         }
 
         public object Instance { get; }
 
         public override async Task<string> Execute(OrchestrationContext context, string input)
         {
-            var parameters = _methodInfo
+            var parameters = PrepareParameters(input, new Dictionary<Type, object>
+            {
+                [typeof(OrchestrationContext)] = context,
+                [typeof(OrchestrationEventReceiver)] = _eventReceiver
+            });
+
+            var result = _methodInfo.Invoke(Instance, parameters);
+
+            return await SerializeResult(result);
+        }
+
+        public override string GetStatus()
+        {
+            return null;
+        }
+
+        public override void RaiseEvent(OrchestrationContext context, string name, string input)
+        {
+            _eventReceiver.RaiseEvent(name, input);
+        }
+
+        private object[] PrepareParameters(
+            string input,
+            Dictionary<Type, object> knownValues)
+        {
+            return _methodInfo
                 .GetParameters()
                 .Select(p =>
                 {
-                    if (p.ParameterType == typeof(OrchestrationContext))
-                        return context;
+                    if (knownValues.TryGetValue(p.ParameterType, out var factory))
+                        return factory;
 
                     if (input == null)
                         return null;
 
-                    return JsonConvert.DeserializeObject(input, p.ParameterType);
+                    return _dataConverter.Deserialize(input, p.ParameterType);
                 }).ToArray();
+        }
 
-            var result = _methodInfo.Invoke(Instance, parameters);
-
+        private async Task<string> SerializeResult(object result)
+        {
             if (result is Task task)
             {
                 await task;
@@ -51,18 +84,9 @@ namespace LLL.DurableTask.Worker.Orchestrations
                 }
             }
 
-            var serializedResult = JsonConvert.SerializeObject(result);
+            var serializedResult = _dataConverter.Serialize(result);
 
             return serializedResult;
-        }
-
-        public override string GetStatus()
-        {
-            return null;
-        }
-
-        public override void RaiseEvent(OrchestrationContext context, string name, string input)
-        {
         }
     }
 }

--- a/src/LLL.DurableTask.Worker/Orchestrations/OrchestrationEventReceiver.cs
+++ b/src/LLL.DurableTask.Worker/Orchestrations/OrchestrationEventReceiver.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using DurableTask.Core.Serializing;
+
+namespace LLL.DurableTask.Worker.Orchestrations
+{
+    public class OrchestrationEventReceiver
+    {
+        private readonly DataConverter _dataConverter;
+        private readonly ConcurrentDictionary<string, ConcurrentQueue<TaskCompletionSource<string>>> _waitingQueues;
+
+        public OrchestrationEventReceiver(DataConverter dataConverter)
+        {
+            _dataConverter = dataConverter;
+            _waitingQueues = new ConcurrentDictionary<string, ConcurrentQueue<TaskCompletionSource<string>>>();
+        }
+
+        public async Task<T> WaitForEventAsync<T>(string eventType, CancellationToken cancellationToken)
+        {
+            var taskCompletionSource = new TaskCompletionSource<string>();
+
+            var waitingQueue = _waitingQueues.GetOrAdd(eventType, _ => new ConcurrentQueue<TaskCompletionSource<string>>());
+
+            waitingQueue.Enqueue(taskCompletionSource);
+
+            using (var registration = cancellationToken.Register(() => taskCompletionSource.TrySetCanceled(cancellationToken)))
+            {
+                var input = await taskCompletionSource.Task;
+                return _dataConverter.Deserialize<T>(input);
+            }
+        }
+
+        public void RaiseEvent(string eventType, string input)
+        {
+            if (_waitingQueues.TryRemove(eventType, out var queue))
+            {
+                while (queue.TryDequeue(out var waitingTask))
+                    waitingTask.TrySetResult(input);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement OrchestrationEventReceiver available when using [Orchestration] attribute on methods.

Usage:
```C#
[Orchestration]
public async Task MyOrchestration(OrchestrationContext context, OrchestrationEventReceiver eventReceiver) {
   ....
   var event = await eventReceiver.WaitForEventAsync<AnEventType>("EventName");
   ...
}
```