### PR TITLE
Reopen completed orchestrations when they receive an event

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,7 @@ services:
         condition: service_healthy
 
   mysql:
-    platform: linux/amd64
-    image: mysql:8.0.22
+    image: mysql:8.0.31
     ports:
       - 3306:3306
     command: --default-authentication-plugin=mysql_native_password
@@ -37,7 +36,6 @@ services:
       - SYS_PTRACE
 
   postgres:
-    platform: linux/amd64
     image: postgres
     ports:
       - 5432:5432

--- a/src/LLL.DurableTask.EFCore.MySql/DependencyInjection/MySqlEFCoreOrchestrationBuilderExtensions.cs
+++ b/src/LLL.DurableTask.EFCore.MySql/DependencyInjection/MySqlEFCoreOrchestrationBuilderExtensions.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 options.UseMySql(connectionString, serverVersion, mysqlOptions =>
                 {
+                    mysqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                     var assemblyName = typeof(MySqlEFCoreOrchestrationBuilderExtensions).Assembly.GetName().Name;
                     mysqlOptions.MigrationsAssembly(assemblyName);
                     mysqlOptionsAction?.Invoke(mysqlOptions);

--- a/src/LLL.DurableTask.EFCore.PostgreSQL/DependencyInjection/PostgreSqlEFCoreOrchestrationBuilderExtensions.cs
+++ b/src/LLL.DurableTask.EFCore.PostgreSQL/DependencyInjection/PostgreSqlEFCoreOrchestrationBuilderExtensions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 options.UseNpgsql(connectionString, npgsqlOptions =>
                 {
+                    npgsqlOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                     var assemblyName = typeof(PostgreSqlEFCoreOrchestrationBuilderExtensions).Assembly.GetName().Name;
                     npgsqlOptions.MigrationsAssembly(assemblyName);
                     mysqlOptionsAction?.Invoke(npgsqlOptions);

--- a/src/LLL.DurableTask.EFCore.SqlServer/DependencyInjection/SqlServerEFCoreOrchestrationBuilderExtensions.cs
+++ b/src/LLL.DurableTask.EFCore.SqlServer/DependencyInjection/SqlServerEFCoreOrchestrationBuilderExtensions.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Extensions.DependencyInjection
             {
                 options.UseSqlServer(connectionString, sqlServerOptions =>
                 {
+                    sqlServerOptions.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery);
                     var assemblyName = typeof(SqlServerEFCoreOrchestrationBuilderExtensions).Assembly.GetName().Name;
                     sqlServerOptions.MigrationsAssembly(assemblyName);
                     mysqlOptionsAction?.Invoke(sqlServerOptions);

--- a/src/LLL.DurableTask.EFCore/Configuration/EventConfiguration.cs
+++ b/src/LLL.DurableTask.EFCore/Configuration/EventConfiguration.cs
@@ -14,7 +14,7 @@ namespace LLL.DurableTask.EFCore.Configuration
             builder.Property(x => x.InstanceId).HasMaxLength(250).IsRequired();
             builder.Property(x => x.ExecutionId).HasMaxLength(100).IsRequired();
             builder.HasOne(x => x.Execution)
-                .WithMany()
+                .WithMany(x => x.Events)
                 .IsRequired()
                 .HasForeignKey(x => x.ExecutionId)
                 .OnDelete(DeleteBehavior.Cascade);

--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
@@ -72,12 +72,8 @@ namespace LLL.DurableTask.EFCore
                 .AsNoTracking()
                 .ToArrayAsync(cancellationToken);
 
-            var isExecutable = RuntimeState.ExecutionStartedEvent == null
-                || RuntimeState.OrchestrationStatus == OrchestrationStatus.Pending
-                || RuntimeState.OrchestrationStatus == OrchestrationStatus.Running;
-
             var messagesToDiscard = newDbMessages
-                .Where(m => !isExecutable || (m.ExecutionId != null && m.ExecutionId != Instance.LastExecutionId))
+                .Where(m => m.ExecutionId != null && m.ExecutionId != Instance.LastExecutionId)
                 .ToArray();
 
             if (messagesToDiscard.Length > 0)

--- a/src/LLL.DurableTask.EFCore/Entities/Execution.cs
+++ b/src/LLL.DurableTask.EFCore/Entities/Execution.cs
@@ -31,5 +31,7 @@ namespace LLL.DurableTask.EFCore.Entities
         public string Input { get; set; }
 
         public string Output { get; set; }
+
+        public IList<Event> Events { get; } = new List<Event>();
     }
 }

--- a/src/LLL.DurableTask.EFCore/Mappers/ExecutionMapper.cs
+++ b/src/LLL.DurableTask.EFCore/Mappers/ExecutionMapper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DurableTask.Core;
+using DurableTask.Core.History;
 using LLL.DurableTask.EFCore.Entities;
 using Microsoft.Extensions.Options;
 
@@ -58,6 +59,24 @@ namespace LLL.DurableTask.EFCore.Mappers
             }
             execution.Tags.RemoveWhere(t => !newTags.Contains(t));
             execution.Tags.UnionWith(newTags);
+        }
+
+        public Event CreateEvent(OrchestrationInstance orchestrationInstance, int sequenceNumber, HistoryEvent historyEvent)
+        {
+            var @event = new Event
+            {
+                Id = Guid.NewGuid(),
+                InstanceId = orchestrationInstance.InstanceId,
+                ExecutionId = orchestrationInstance.ExecutionId,
+                SequenceNumber = sequenceNumber
+            };
+            UpdateEvent(@event, historyEvent);
+            return @event;
+        }
+
+        public void UpdateEvent(Event @event, HistoryEvent historyEvent)
+        {
+            @event.Content = _options.DataConverter.Serialize(historyEvent);
         }
 
         public OrchestrationState MapToState(Execution execution)

--- a/test/LLL.DurableTask.Tests/Storages/AzureStorageServerTests.cs
+++ b/test/LLL.DurableTask.Tests/Storages/AzureStorageServerTests.cs
@@ -15,6 +15,7 @@ namespace LLL.DurableTask.Tests.Storages
             SlowWaitTimeout *= 2;
             SupportsMultipleExecutionStorage = false;
             SupportsTags = false;
+            SupportsEventsAfterCompletion = false;
         }
 
         protected override void ConfigureServerStorage(IServiceCollection services)

--- a/test/LLL.DurableTask.Tests/Storages/AzureStorageTests.cs
+++ b/test/LLL.DurableTask.Tests/Storages/AzureStorageTests.cs
@@ -16,6 +16,7 @@ namespace LLL.DurableTask.Tests.Storages
             SlowWaitTimeout *= 2;
             SupportsMultipleExecutionStorage = false;
             SupportsTags = false;
+            SupportsEventsAfterCompletion = false;
         }
 
         protected override void ConfigureStorage(IServiceCollection services)

--- a/test/LLL.DurableTask.Tests/Storages/EmulatorTests.cs
+++ b/test/LLL.DurableTask.Tests/Storages/EmulatorTests.cs
@@ -8,6 +8,9 @@ namespace LLL.DurableTask.Tests.Storages
     {
         public EmulatorServerTests(ITestOutputHelper output) : base(output)
         {
+            SupportsMultipleExecutionStorage = false;
+            SupportsTags = false;
+            SupportsEventsAfterCompletion = false;
         }
 
         protected override void ConfigureStorage(IServiceCollection services)

--- a/test/LLL.DurableTask.Tests/Storages/Orchestrations/EmptyOrchestration.cs
+++ b/test/LLL.DurableTask.Tests/Storages/Orchestrations/EmptyOrchestration.cs
@@ -12,5 +12,11 @@ namespace LLL.DurableTask.Tests.Storage.Orchestrations
         {
             return Task.FromResult(input);
         }
+
+        public override void OnEvent(OrchestrationContext context, string name, string input)
+        {
+            base.OnEvent(context, name, input);
+            context.ContinueAsNew(input);
+        }
     }
 }


### PR DESCRIPTION
I have use cases where it's important to process all events.

The is the flow:

1. The client creates an execution with an event
2. Orchestration started
2.1. Wait a few seconds to receive an event
2.2. While (received events)
2.2.1. Process received events
2.2.2. Wait a few seconds to receive more events
2.3. Complete orchestration without continuing as new
3. Orchestration completed
4. Client puts more events in the orchestration queue
5. Execution is saved as completed in the database
6. Events are picked up and discarded because the latest execution is completed

Then repeat... A client creates a new execution with an event because the current execution is already completed. 

This diff changes item 6 above to:

- Reopen execution by just removing the "ExecutionCompleted" or "ExecutionFailed" event.
- Execute orchestration again with the new events

Then orchestration code will receive the event and will "ContinueAsNew" from inside the "OnEvent" method.