### PR TITLE
Add support for registering activity methods from interfaces

### DIFF
--- a/benchmark/StoragesBenchmark/OrchestrationBenchmark.cs
+++ b/benchmark/StoragesBenchmark/OrchestrationBenchmark.cs
@@ -61,7 +61,7 @@ namespace StoragesBenchmark
 
         protected virtual void ConfigureWorker(IDurableTaskWorkerBuilder builder)
         {
-            builder.AddFromType(typeof(Orchestrations));
+            builder.AddAnnotatedFromType(typeof(Orchestrations));
         }
 
         [Benchmark]

--- a/samples/BpmnWorker/Program.cs
+++ b/samples/BpmnWorker/Program.cs
@@ -42,7 +42,7 @@ namespace WorkflowApi
 
             services.AddDurableTaskWorker(builder =>
             {
-                builder.AddFromAssembly(typeof(Program).Assembly);
+                builder.AddAnnotatedFromAssembly(typeof(Program).Assembly);
             });
 
             services.AddSingleton<IBPMNProvider, LocalFileBPMNProvider>();

--- a/samples/CarWorker/Program.cs
+++ b/samples/CarWorker/Program.cs
@@ -39,7 +39,7 @@ namespace CarWorker
 
             services.AddDurableTaskWorker(builder =>
             {
-                builder.AddFromAssembly(typeof(Program).Assembly);
+                builder.AddAnnotatedFromAssembly(typeof(Program).Assembly);
             });
         }
     }

--- a/samples/FlightWorker/Program.cs
+++ b/samples/FlightWorker/Program.cs
@@ -39,7 +39,7 @@ namespace FlightWorker
 
             services.AddDurableTaskWorker(builder =>
             {
-                builder.AddFromAssembly(typeof(Program).Assembly);
+                builder.AddAnnotatedFromAssembly(typeof(Program).Assembly);
             });
         }
     }

--- a/samples/HotelWorker/Program.cs
+++ b/samples/HotelWorker/Program.cs
@@ -39,7 +39,7 @@ namespace HotelWorker
 
             services.AddDurableTaskWorker(builder =>
             {
-                builder.AddFromAssembly(typeof(Program).Assembly);
+                builder.AddAnnotatedFromAssembly(typeof(Program).Assembly);
             });
         }
     }

--- a/samples/OrchestrationWorker/Program.cs
+++ b/samples/OrchestrationWorker/Program.cs
@@ -39,7 +39,7 @@ namespace OrchestrationWorker
 
             services.AddDurableTaskWorker(builder =>
             {
-                builder.AddFromAssembly(typeof(Program).Assembly);
+                builder.AddAnnotatedFromAssembly(typeof(Program).Assembly);
             });
         }
     }

--- a/src/LLL.DurableTask.Worker/README.md
+++ b/src/LLL.DurableTask.Worker/README.md
@@ -31,19 +31,28 @@ services.AddDurableTaskWorker(builder =>
 });
 ```
 
-Or you can also scan an assembly to add all orchestrations and/or activities marked with attributes [OrchestrationAttribute](src/LLL.DurableTask.Worker/Attributes/OrchestrationAttribute.cs) or [ActivityAttribute](src/LLL.DurableTask.Worker/Attributes/ActivityAttribute.cs):
+Or you can also scan an assembly to add all orchestrations and/or activities annotated with attributes [OrchestrationAttribute](src/LLL.DurableTask.Worker/Attributes/OrchestrationAttribute.cs) or [ActivityAttribute](src/LLL.DurableTask.Worker/Attributes/ActivityAttribute.cs):
 
 ```C#
 services.AddDurableTaskWorker(builder =>
 {
     // Adds all orchestrations and activities from assembly
-    builder.AddFromAssembly(typeof(Startup).Assembly);
+    builder.AddAnnotatedFromAssembly(typeof(Startup).Assembly);
 
     // Add only orchestrations from assembly
-    builder.AddOrchestrationsFromAssembly(typeof(Startup).Assembly);
+    builder.AddAnnotatedOrchestrationsFromAssembly(typeof(Startup).Assembly);
 
     // Add only activities from assembly
-    builder.AddActivitiesFromAssembly(typeof(Startup).Assembly);
+    builder.AddAnnotatedActivitiesFromAssembly(typeof(Startup).Assembly);
+});
+```
+
+Registering activities from interfaces:
+```C#
+services.AddDurableTaskWorker(builder =>
+{
+    // Add all interface methods as activities
+    builder.AddActivitiesFromInterface<IMyActivities, MyActivities>();
 });
 ```
 

--- a/test/LLL.DurableTask.Tests/Worker/ActivityClass/ConstructorInjectionTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityClass/ConstructorInjectionTests.cs
@@ -32,8 +32,8 @@ namespace LLL.DurableTask.Tests.Worker.ActivityClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(InvokeActivityOrchestration));
-            builder.AddFromType(typeof(TestActivity));
+            builder.AddAnnotatedFromType(typeof(InvokeActivityOrchestration));
+            builder.AddAnnotatedFromType(typeof(TestActivity));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/ActivityClass/FailureDetailsTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityClass/FailureDetailsTests.cs
@@ -23,8 +23,8 @@ namespace LLL.DurableTask.Tests.Worker.ActivityClass
             base.ConfigureWorker(builder);
 
             builder
-                .AddFromType(typeof(InvokeActivityOrchestration))
-                .AddFromType(typeof(ThrowActivity));
+                .AddAnnotatedFromType(typeof(InvokeActivityOrchestration))
+                .AddAnnotatedFromType(typeof(ThrowActivity));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/ActivityClass/SerializeResultTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityClass/SerializeResultTests.cs
@@ -22,9 +22,9 @@ namespace LLL.DurableTask.Tests.Worker.ActivityClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(InvokeActivityOrchestration));
-            builder.AddFromType(typeof(AsyncReturnGenericTaskString));
-            builder.AddFromType(typeof(ReturnGenericTaskString));
+            builder.AddAnnotatedFromType(typeof(InvokeActivityOrchestration));
+            builder.AddAnnotatedFromType(typeof(AsyncReturnGenericTaskString));
+            builder.AddAnnotatedFromType(typeof(ReturnGenericTaskString));
         }
 
         [InlineData("AsyncReturnGenericTaskString", "\"Something\"")]

--- a/test/LLL.DurableTask.Tests/Worker/ActivityMethod/ConstructorInjectionTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityMethod/ConstructorInjectionTests.cs
@@ -31,8 +31,8 @@ namespace LLL.DurableTask.Tests.Worker.ActivityMethod
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(InvokeActivityOrchestration));
-            builder.AddFromType(typeof(Activities));
+            builder.AddAnnotatedFromType(typeof(InvokeActivityOrchestration));
+            builder.AddAnnotatedFromType(typeof(Activities));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/ActivityMethod/FailureDetailsTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityMethod/FailureDetailsTests.cs
@@ -22,8 +22,8 @@ namespace LLL.DurableTask.Tests.Worker.ActivityMethod
             base.ConfigureWorker(builder);
 
             builder
-                .AddFromType(typeof(InvokeActivityOrchestration))
-                .AddFromType(typeof(Activities));
+                .AddAnnotatedFromType(typeof(InvokeActivityOrchestration))
+                .AddAnnotatedFromType(typeof(Activities));
         }
 
         [InlineData("AsyncThrow")]

--- a/test/LLL.DurableTask.Tests/Worker/ActivityMethod/SerializeResultTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/ActivityMethod/SerializeResultTests.cs
@@ -21,8 +21,8 @@ namespace LLL.DurableTask.Tests.Worker.ActivityMethod
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(InvokeActivityOrchestration));
-            builder.AddFromType(typeof(Activities));
+            builder.AddAnnotatedFromType(typeof(InvokeActivityOrchestration));
+            builder.AddAnnotatedFromType(typeof(Activities));
         }
 
         [InlineData("AsyncReturnGenericTaskString", "\"Something\"")]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/ConstructorInjectionTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/ConstructorInjectionTests.cs
@@ -31,7 +31,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(TestOrchestration));
+            builder.AddAnnotatedFromType(typeof(TestOrchestration));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/EventReceiverTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/EventReceiverTests.cs
@@ -23,8 +23,8 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(WaitForEventOrchestration));
-            builder.AddFromType(typeof(AddEventListenerOrchestration));
+            builder.AddAnnotatedFromType(typeof(WaitForEventOrchestration));
+            builder.AddAnnotatedFromType(typeof(AddEventListenerOrchestration));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/FailureDetailsTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/FailureDetailsTests.cs
@@ -22,7 +22,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationClass
             base.ConfigureWorker(builder);
 
             builder
-                .AddFromType(typeof(ThrowOrchestration));
+                .AddAnnotatedFromType(typeof(ThrowOrchestration));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/GuidGenerationTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/GuidGenerationTests.cs
@@ -22,7 +22,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(GenerateGuidOrchestration));
+            builder.AddAnnotatedFromType(typeof(GenerateGuidOrchestration));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/SerializeResultTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationClass/SerializeResultTests.cs
@@ -21,8 +21,8 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationClass
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(AsyncReturnGenericTaskString));
-            builder.AddFromType(typeof(ReturnGenericTaskString));
+            builder.AddAnnotatedFromType(typeof(AsyncReturnGenericTaskString));
+            builder.AddAnnotatedFromType(typeof(ReturnGenericTaskString));
         }
 
         [InlineData("AsyncReturnGenericTaskString", "\"Something\"")]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/EventReceiverTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/EventReceiverTests.cs
@@ -23,7 +23,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationMethod
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(Orchestrations));
+            builder.AddAnnotatedFromType(typeof(Orchestrations));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/FailureDetailsTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/FailureDetailsTests.cs
@@ -21,7 +21,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationMethod
             base.ConfigureWorker(builder);
 
             builder
-                .AddFromType(typeof(Orchestrations));
+                .AddAnnotatedFromType(typeof(Orchestrations));
         }
 
         [InlineData("AsyncThrow")]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/GuidGenerationTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/GuidGenerationTests.cs
@@ -22,7 +22,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationMethod
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(Orchestrations));
+            builder.AddAnnotatedFromType(typeof(Orchestrations));
         }
 
         [Fact]

--- a/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/SerializeResultTests.cs
+++ b/test/LLL.DurableTask.Tests/Worker/OrchestrationMethod/SerializeResultTests.cs
@@ -20,7 +20,7 @@ namespace LLL.DurableTask.Tests.Worker.OrchestrationMethod
         {
             base.ConfigureWorker(builder);
 
-            builder.AddFromType(typeof(Orchestrations));
+            builder.AddAnnotatedFromType(typeof(Orchestrations));
         }
 
         [InlineData("AsyncReturnGenericTaskString", "\"Something\"")]


### PR DESCRIPTION
Add support for registering activity methods from interfaces
Rename existing annotation-based registration methods.

Fixes #21