### PR TITLE
Orchestration with a timer keeps running after termination

### DIFF
--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
@@ -87,6 +87,20 @@ public class EFCoreOrchestrationSession : IOrchestrationSession
                 .ToArray();
         }
 
+        var isRunning = RuntimeState.ExecutionStartedEvent == null
+                        || RuntimeState.OrchestrationStatus is OrchestrationStatus.Running
+                            or OrchestrationStatus.Suspended
+                            or OrchestrationStatus.Pending;
+        if (!isRunning)
+        {
+            foreach (var message in newDbMessages)
+            {
+                dbContext.OrchestrationMessages.Attach(message);
+                dbContext.OrchestrationMessages.Remove(message);
+            }
+            newDbMessages = [];
+        }
+
         Messages.AddRange(newDbMessages);
 
         var deserializedMessages = newDbMessages


### PR DESCRIPTION
In an orchestration with timer, timer is fired even after the orchestration is terminated which causes the orchestration to keep running.

Below is the simplified version of our orchestration logic
```
for (int i = 0; i < 10; i++)
{
	await context.CreateTimer(context.CurrentUtcDateTime.AddSeconds(15), $"timer{i}").ConfigureAwait(true);
	// Logic and Activities execution
}

context.ContinueAsNew(input);
return new();
```

**History screenshot:**
![image](https://github.com/user-attachments/assets/aac5f495-42d6-4be3-9e6e-04eefd041871)
