### PR TITLE
Fix orchestrations keep running after termination due to timers

### DIFF
--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationService.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationService.cs
@@ -7,7 +7,6 @@ using DurableTask.Core;
 using DurableTask.Core.History;
 using LLL.DurableTask.Core;
 using LLL.DurableTask.EFCore.Entities;
-using LLL.DurableTask.EFCore.Extensions;
 using LLL.DurableTask.EFCore.Mappers;
 using LLL.DurableTask.EFCore.Polling;
 using Microsoft.EntityFrameworkCore;
@@ -135,9 +134,7 @@ public partial class EFCoreOrchestrationService :
                 .Select(e => _options.DataConverter.Deserialize<HistoryEvent>(e.Content))
                 .ToArray();
 
-            var reopenedEvents = deserializedEvents.Reopen(_options.DataConverter);
-
-            var runtimeState = new OrchestrationRuntimeState(reopenedEvents);
+            var runtimeState = new OrchestrationRuntimeState(deserializedEvents);
 
             var session = new EFCoreOrchestrationSession(
                 _options,
@@ -163,7 +160,7 @@ public partial class EFCoreOrchestrationService :
             {
                 InstanceId = instance.InstanceId,
                 LockedUntilUtc = instance.LockedUntil,
-                OrchestrationRuntimeState = runtimeState,
+                OrchestrationRuntimeState = session.RuntimeState,
                 NewMessages = messages,
                 Session = session
             };

--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
@@ -4,7 +4,9 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DurableTask.Core;
+using DurableTask.Core.History;
 using LLL.DurableTask.EFCore.Entities;
+using LLL.DurableTask.EFCore.Extensions;
 using LLL.DurableTask.EFCore.Polling;
 using Microsoft.EntityFrameworkCore;
 
@@ -87,25 +89,39 @@ public class EFCoreOrchestrationSession : IOrchestrationSession
                 .ToArray();
         }
 
-        var isRunning = RuntimeState.ExecutionStartedEvent == null
-                        || RuntimeState.OrchestrationStatus is OrchestrationStatus.Running
-                            or OrchestrationStatus.Suspended
-                            or OrchestrationStatus.Pending;
-        if (!isRunning)
-        {
-            foreach (var message in newDbMessages)
-            {
-                dbContext.OrchestrationMessages.Attach(message);
-                dbContext.OrchestrationMessages.Remove(message);
-            }
-            newDbMessages = [];
-        }
-
-        Messages.AddRange(newDbMessages);
-
         var deserializedMessages = newDbMessages
             .Select(w => _options.DataConverter.Deserialize<TaskMessage>(w.Message))
             .ToList();
+
+        if (RuntimeState.ExecutionStartedEvent is not null)
+        {
+            if (RuntimeState.OrchestrationStatus is OrchestrationStatus.Completed
+                && deserializedMessages.Any(m => m.Event.EventType == EventType.EventRaised))
+            {
+                // Reopen completed orchestrations after receiving an event raised
+                RuntimeState = new OrchestrationRuntimeState(
+                    RuntimeState.Events.Reopen(_options.DataConverter)
+                );
+            }
+
+            var isRunning = RuntimeState.OrchestrationStatus is OrchestrationStatus.Running
+                    or OrchestrationStatus.Suspended
+                    or OrchestrationStatus.Pending;
+
+            if (!isRunning)
+            {
+                // Discard all messages if not running
+                foreach (var message in newDbMessages)
+                {
+                    dbContext.OrchestrationMessages.Attach(message);
+                    dbContext.OrchestrationMessages.Remove(message);
+                }
+                newDbMessages = [];
+                deserializedMessages = [];
+            }
+        }
+
+        Messages.AddRange(newDbMessages);
 
         return deserializedMessages;
     }

--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
@@ -87,6 +87,20 @@ public class EFCoreOrchestrationSession : IOrchestrationSession
                 .ToArray();
         }
 
+        var isRunning = RuntimeState.ExecutionStartedEvent == null
+                        || RuntimeState.OrchestrationStatus is OrchestrationStatus.Running
+                            or OrchestrationStatus.Suspended
+                            or OrchestrationStatus.Pending;
+        if (!isRunning)
+        {
+            foreach (var message in newDbMessages)
+            {
+                dbContext.OrchestrationMessages.Attach(message);
+                dbContext.OrchestrationMessages.Remove(message);
+            }
+            newDbMessages = [];
+        }
+
         Messages.AddRange(newDbMessages);
 
         var deserializedMessages = newDbMessages


### PR DESCRIPTION
Follow-ups on top of https://github.com/lucaslorentz/durabletask-extensions/pull/41:
- Add test
- Fix re-opening of completed orchestrations after events.
