### PR TITLE
Add 3-day cooldown and skip TFM-conditional packages in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,15 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       dotnet:
         patterns:
           - "*"
     ignore:
+      - dependency-name: "Microsoft.EntityFrameworkCore.*"
+      - dependency-name: "Microsoft.Extensions.*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
 
@@ -16,6 +20,8 @@ updates:
     directory: /src/LLL.DurableTask.Ui/app
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       npm:
         patterns:
@@ -28,6 +34,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       github-actions:
         patterns:
@@ -37,6 +45,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
     groups:
       docker:
         patterns:

--- a/src/LLL.DurableTask.Ui/app/package.json
+++ b/src/LLL.DurableTask.Ui/app/package.json
@@ -42,10 +42,5 @@
     "preview": "vite preview",
     "test": "playwright test",
     "test:e2e": "playwright test"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/src/LLL.DurableTask.Ui/app/pnpm-workspace.yaml
+++ b/src/LLL.DurableTask.Ui/app/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+onlyBuiltDependencies:
+  - esbuild

--- a/src/LLL.DurableTask.Ui/app/pnpm-workspace.yaml
+++ b/src/LLL.DurableTask.Ui/app/pnpm-workspace.yaml
@@ -1,2 +1,2 @@
-onlyBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## Summary

Two changes to `.github/dependabot.yml` driven by the failures on PRs #85 and #89:

- **Add `cooldown: default-days: 3`** to every ecosystem block. This avoids the `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION` that broke PR #89, where `@babel/runtime@7.29.7` ended up in the lockfile less than 24h after publication and pnpm's supply-chain guard rejected it.
- **Ignore `Microsoft.EntityFrameworkCore.*` and `Microsoft.Extensions.*`** in the nuget block. These packages are referenced inside `<ItemGroup Condition="'$(TargetFramework)' == 'netX.0'">` blocks across `src/`, and dependabot does not respect those conditions: it aggregates a package by name across the csproj and bumps every line to the same version. PR #85 showed this concretely — the `net8.0` block was bumped from `8.0.25` to `9.0.15`, which crosses a major (so the existing `ignore: version-update:semver-major` should have blocked it but didn't, since dependabot saw it as a patch from `9.0.14`). That created an unresolvable NU1107 conflict with `Pomelo.EntityFrameworkCore.MySql 8.0.3`, which constrains Relational to `<= 8.0.999`.

These two families track the .NET release cadence, so bumping them by hand is low-cost and safer than fighting the tool.

## Test plan

- [ ] Dependabot rebases #85 / #89 (or opens new grouped PRs) without bumping `Microsoft.EntityFrameworkCore.*` / `Microsoft.Extensions.*`
- [ ] No new PRs appear with packages published in the last 3 days

🤖 Generated with [Claude Code](https://claude.com/claude-code)