### PR TITLE
Bump DurableTask.Core to 3.8.0 (implements IOrchestrationSession.EndSessionAsync)

### DIFF
--- a/src/LLL.DurableTask.Client/LLL.DurableTask.Client.csproj
+++ b/src/LLL.DurableTask.Client/LLL.DurableTask.Client.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LLL.DurableTask.Core/LLL.DurableTask.Core.csproj
+++ b/src/LLL.DurableTask.Core/LLL.DurableTask.Core.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationSession.cs
@@ -130,4 +130,9 @@ public class EFCoreOrchestrationSession : IOrchestrationSession
     {
         Messages.Clear();
     }
+
+    public Task EndSessionAsync()
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/src/LLL.DurableTask.EFCore/LLL.DurableTask.EFCore.csproj
+++ b/src/LLL.DurableTask.EFCore/LLL.DurableTask.EFCore.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LLL.DurableTask.Server.Grpc.Client/GrpcClientOrchestrationSession.cs
+++ b/src/LLL.DurableTask.Server.Grpc.Client/GrpcClientOrchestrationSession.cs
@@ -165,4 +165,9 @@ public class GrpcClientOrchestrationSession : IOrchestrationSession
 
         _stream.Dispose();
     }
+
+    public Task EndSessionAsync()
+    {
+        return Task.CompletedTask;
+    }
 }

--- a/src/LLL.DurableTask.Server.Grpc.Client/LLL.DurableTask.Server.Grpc.Client.csproj
+++ b/src/LLL.DurableTask.Server.Grpc.Client/LLL.DurableTask.Server.Grpc.Client.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Grpc.Tools" Version="2.80.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/LLL.DurableTask.Server.Grpc/LLL.DurableTask.Server.Grpc.csproj
+++ b/src/LLL.DurableTask.Server.Grpc/LLL.DurableTask.Server.Grpc.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LLL.DurableTask.Server/LLL.DurableTask.Server.csproj
+++ b/src/LLL.DurableTask.Server/LLL.DurableTask.Server.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/LLL.DurableTask.Worker/LLL.DurableTask.Worker.csproj
+++ b/src/LLL.DurableTask.Worker/LLL.DurableTask.Worker.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.7.1" />
+    <PackageReference Include="Microsoft.Azure.DurableTask.Core" Version="3.8.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Splits the only code-requiring change out of dependabot PR #93: the `Microsoft.Azure.DurableTask.Core` bump from **3.7.1 → 3.8.0**.

3.8.0 is a **breaking interface change** — it adds `EndSessionAsync()` to `IOrchestrationSession` (introduced for the extended-sessions use case). Two of our session implementations don't implement it, so a plain version bump fails to compile (`CS0535`), which is why the grouped dependabot PR #93 was red.

The dispatcher only calls `session.EndSessionAsync()` in the extended-session path, right after releasing the concurrency lock ([TaskOrchestrationDispatcher.cs](https://github.com/Azure/durabletask/blob/main/src/DurableTask.Core/TaskOrchestrationDispatcher.cs)). These storage providers don't use extended sessions, so a no-op returning `Task.CompletedTask` is the correct implementation.

## Changes

- `Microsoft.Azure.DurableTask.Core` 3.7.1 → 3.8.0 across the 7 `src/` projects that reference it directly.
- Implement `EndSessionAsync()` (no-op) in:
  - `EFCoreOrchestrationSession`
  - `GrpcClientOrchestrationSession`

The rest of PR #93's group (Grpc, Protobuf, AzureStorage, SourceLink, ClearScript, Aspire, Test.Sdk) is intentionally left out — those need no code changes and dependabot can apply them once this lands. Note `AzureStorage 2.9.0` transitively requires Core ≥ 3.8.0, so this PR unblocks that bump.

## Test plan

- [x] `dotnet build -c Release` — 0 errors (only the pre-existing NU1608 Pomelo/Relational warnings)
- [x] `dotnet test --filter "FullyQualifiedName~InMemory"` — 32/32 passing on net8.0, net9.0, net10.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)