### PR TITLE
ci: floating major tags for Actions, silence patch/minor Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,12 @@ updates:
       github-actions:
         patterns:
           - "*"
+    # Actions are pinned to floating major tags (e.g. @v6), so minor/patch
+    # updates are picked up automatically. Only open PRs for major bumps.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.201
 
@@ -116,7 +116,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5.2.0
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.201
 


### PR DESCRIPTION
## What

Low-maintenance approach for GitHub Actions versioning:

- `build.yml`: `actions/setup-dotnet@v5.2.0` → `@v5` (both jobs). `checkout@v6` and `upload-artifact@v7` already used floating major tags — now everything is consistent.
- `dependabot.yml`: ignore `semver-minor` / `semver-patch` for the `github-actions` group.

## Why

A floating major tag (`@v5`, `@v6`, `@v7`) is moved by the maintainers to the latest release within that major — so minor/patch fixes are picked up automatically, no PR needed. Dependabot will now only open a PR when a **new major** ships (e.g. `checkout@v6` → `@v7`), which is the case that actually warrants a review (breaking inputs, Node runtime bumps, etc.).

This supersedes #96, which did the opposite: it would have pinned `checkout@v6` → `@v6.0.2`, freezing the floating tag and trading away the free auto-updates without the reproducibility/security benefit of full SHA pinning.

Close #96 in favor of this.