### PR TITLE
perf: cancel an orchestration's pending timers when it finishes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,7 @@ BenchmarkDotNet.Artifacts
 *.png
 *.jpeg
 playwright-report/
+test-results/
+
+# Language server cache
+*.lscache

--- a/src/LLL.DurableTask.EFCore/EFCoreOrchestrationService.cs
+++ b/src/LLL.DurableTask.EFCore/EFCoreOrchestrationService.cs
@@ -354,6 +354,23 @@ public partial class EFCoreOrchestrationService :
             dbContext.AttachRange(session.Messages);
             dbContext.OrchestrationMessages.RemoveRange(session.Messages);
 
+            // Cancel the execution's pending timers when it finishes, so they don't
+            // linger in the queue (e.g. an unfired timeout from a Task.WhenAny) or
+            // fire against an already-finished orchestration. ContinuedAsNew/Suspended
+            // are excluded: those executions can still run.
+            var completedRuntimeState = workItem.OrchestrationRuntimeState;
+            if (completedRuntimeState.OrchestrationStatus is OrchestrationStatus.Completed
+                or OrchestrationStatus.Failed
+                or OrchestrationStatus.Terminated
+                or OrchestrationStatus.Canceled)
+            {
+                await CancelPendingTimersAsync(
+                    dbContext,
+                    completedRuntimeState.OrchestrationInstance.InstanceId,
+                    completedRuntimeState.OrchestrationInstance.ExecutionId,
+                    session.Messages.Select(m => m.Id).ToArray());
+            }
+
             // Update instance
             _instanceMapper.UpdateInstance(session.Instance, newOrchestrationRuntimeState);
 
@@ -425,6 +442,28 @@ public partial class EFCoreOrchestrationService :
 
             await dbContext.OrchestrationMessages.AddRangeAsync(orchestrationMessages);
         }
+    }
+
+    private async Task CancelPendingTimersAsync(
+        OrchestrationDbContext dbContext,
+        string instanceId,
+        string executionId,
+        IReadOnlyCollection<Guid> consumedMessageIds)
+    {
+        // Runs under the instance lock (Complete owns the instance), so no skip-locked
+        // is needed. Match timers by event type, not by AvailableAt, so a timer that
+        // became due between the last fetch and now is included too. Exclude the
+        // messages already read/processed in this work item (they are deleted
+        // separately) so the query only returns still-pending messages.
+        var pendingTimers = (await dbContext.OrchestrationMessages
+            .Where(m => m.InstanceId == instanceId
+                && m.ExecutionId == executionId
+                && !consumedMessageIds.Contains(m.Id))
+            .ToListAsync())
+            .Where(m => _options.DataConverter.Deserialize<TaskMessage>(m.Message).Event is TimerFiredEvent)
+            .ToList();
+
+        dbContext.OrchestrationMessages.RemoveRange(pendingTimers);
     }
 
     private async Task<Execution> SaveExecutionAsync(

--- a/test/LLL.DurableTask.Tests/Storages/EFCoreTestBase.cs
+++ b/test/LLL.DurableTask.Tests/Storages/EFCoreTestBase.cs
@@ -23,6 +23,27 @@ public abstract class EFCoreTestBase : StorageTestBase
         _output = output;
     }
 
+    protected override async Task AssertNoPendingMessagesAsync(string instanceId)
+    {
+        var dbContextFactory = _host.Services.GetRequiredService<IDbContextFactory<OrchestrationDbContext>>();
+
+        var deadline = DateTime.UtcNow + FastWaitTimeout;
+        while (true)
+        {
+            using var dbContext = await dbContextFactory.CreateDbContextAsync();
+            var pending = await dbContext.OrchestrationMessages
+                .CountAsync(m => m.InstanceId == instanceId);
+
+            if (pending == 0 || DateTime.UtcNow >= deadline)
+            {
+                pending.Should().Be(0, "a terminated orchestration should leave no pending messages");
+                return;
+            }
+
+            await Task.Delay(50);
+        }
+    }
+
     [SkippableFact]
     public async Task TryLockNextInstanceAsync()
     {

--- a/test/LLL.DurableTask.Tests/Storages/Orchestrations/ManyTimersOrchestration.cs
+++ b/test/LLL.DurableTask.Tests/Storages/Orchestrations/ManyTimersOrchestration.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using LLL.DurableTask.Worker;
+
+namespace LLL.DurableTask.Tests.Storage.Orchestrations;
+
+public class ManyTimersOrchestration : OrchestrationBase<object, object>
+{
+    public const string Name = "ManyTimers";
+    public const string Version = "v1";
+
+    public override async Task<object> Execute(object input)
+    {
+        // Schedule many timers 500ms apart (spanning ~50s) and publish how many have
+        // fired so far. The spacing guarantees some fire during the test (so we
+        // terminate while the orchestration is actively timing), while the later ones
+        // are too far out to fire within the test's polling window — so an empty queue
+        // afterwards proves terminating cancelled them rather than them just firing.
+        var fired = 0;
+        Context.SetStatusProvider(() => fired);
+
+        var timers = new List<Task>();
+        for (var i = 1; i <= 100; i++)
+        {
+            timers.Add(Context.CreateTimer<object>(Context.CurrentUtcDateTime.AddMilliseconds(i * 500), null));
+        }
+
+        foreach (var timer in timers)
+        {
+            await timer;
+            fired++;
+        }
+
+        return fired;
+    }
+}

--- a/test/LLL.DurableTask.Tests/Storages/Orchestrations/TimerOrchestration.cs
+++ b/test/LLL.DurableTask.Tests/Storages/Orchestrations/TimerOrchestration.cs
@@ -11,7 +11,7 @@ public class TimerOrchestration : TaskOrchestration<object, object>
 
     public override async Task<object> RunTask(OrchestrationContext context, object input)
     {
-        var output = await context.CreateTimer<object>(DateTime.UtcNow.AddSeconds(2), input);
+        var output = await context.CreateTimer<object>(DateTime.UtcNow.AddSeconds(1), input);
         return output;
     }
 }

--- a/test/LLL.DurableTask.Tests/Storages/StorageTestBase.cs
+++ b/test/LLL.DurableTask.Tests/Storages/StorageTestBase.cs
@@ -4,10 +4,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using AwesomeAssertions;
 using DurableTask.Core;
-using DurableTask.Core.History;
 using DurableTask.Core.Query;
 using LLL.DurableTask.Core;
-using LLL.DurableTask.Core.Serializing;
 using LLL.DurableTask.EFCore.Polling;
 using LLL.DurableTask.Tests.Storage.Activities;
 using LLL.DurableTask.Tests.Storage.Orchestrations;
@@ -78,6 +76,7 @@ public abstract class StorageTestBase : IAsyncLifetime
     {
         builder.AddOrchestration<EmptyOrchestration>(EmptyOrchestration.Name, EmptyOrchestration.Version);
         builder.AddOrchestration<TimerOrchestration>(TimerOrchestration.Name, TimerOrchestration.Version);
+        builder.AddOrchestration<ManyTimersOrchestration>(ManyTimersOrchestration.Name, ManyTimersOrchestration.Version);
         builder.AddOrchestration<ContinueAsNewOrchestration>(ContinueAsNewOrchestration.Name, ContinueAsNewOrchestration.Version);
         builder.AddOrchestration<ContinueAsNewEmptyOrchestration>(ContinueAsNewEmptyOrchestration.Name, ContinueAsNewEmptyOrchestration.Version);
         builder.AddOrchestration<ParentOrchestration>(ParentOrchestration.Name, ParentOrchestration.Version);
@@ -171,18 +170,19 @@ public abstract class StorageTestBase : IAsyncLifetime
 
     [Trait("Category", "Integration")]
     [SkippableFact]
-    public async Task TimerOrchestration_ShouldTerminateProperly()
+    public async Task TerminatedOrchestration_ShouldCancelPendingTimers()
     {
         var taskHubClient = _host.Services.GetRequiredService<TaskHubClient>();
 
-        var input = Guid.NewGuid();
-
         var instance = await taskHubClient.CreateOrchestrationInstanceAsync(
-            TimerOrchestration.Name,
-            TimerOrchestration.Version,
-            input);
+            ManyTimersOrchestration.Name,
+            ManyTimersOrchestration.Version,
+            null);
 
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        // Wait until at least one timer has fired (the orchestration publishes its
+        // fired count as status), so we terminate while it is actively timing and
+        // most of its timers are still pending.
+        await WaitUntilAnyTimerFiredAsync(taskHubClient, instance);
 
         await taskHubClient.TerminateInstanceAsync(instance);
 
@@ -191,12 +191,33 @@ public abstract class StorageTestBase : IAsyncLifetime
         state.Should().NotBeNull();
         state.OrchestrationStatus.Should().Be(OrchestrationStatus.Terminated);
 
-        await Task.Delay(TimeSpan.FromSeconds(3));
+        // Terminating must cancel the still-pending timers. The later ones cannot fire
+        // within this window, so an empty queue proves they were cancelled.
+        await AssertNoPendingMessagesAsync(instance.InstanceId);
+    }
 
-        var history = await taskHubClient.GetOrchestrationHistoryAsync(instance);
+    // Overridden by storages that can inspect their message queue; no-op otherwise.
+    protected virtual Task AssertNoPendingMessagesAsync(string instanceId)
+    {
+        return Task.CompletedTask;
+    }
 
-        var events = new TypelessJsonDataConverter().Deserialize<HistoryEvent[]>(history);
-        events.Should().NotContain(x => x.EventType == EventType.TimerFired);
+    private async Task WaitUntilAnyTimerFiredAsync(
+        TaskHubClient taskHubClient,
+        OrchestrationInstance instance)
+    {
+        var deadline = DateTime.UtcNow + FastWaitTimeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            var state = await taskHubClient.GetOrchestrationStateAsync(instance.InstanceId);
+
+            if (int.TryParse(state?.Status, out var firedCount) && firedCount >= 1)
+                return;
+
+            await Task.Delay(50);
+        }
+
+        throw new TimeoutException("No timer fired in time.");
     }
 
     [Trait("Category", "Integration")]


### PR DESCRIPTION
**Optimization, not a bug fix.** When an orchestration finishes, its still-pending timers are already harmless — they're dropped when they fire (the orchestration is no longer running). This just discards them **earlier**, when the execution reaches a terminal state, so e.g. an unfired `Task.WhenAny` timeout doesn't sit in the queue until its (possibly far-off) due time.

Also replaces the flaky `TimerOrchestration_ShouldTerminateProperly` test with `TerminatedOrchestration_ShouldCancelPendingTimers`: it schedules many timers 500ms apart, terminates after at least one has fired (while the rest are still pending), and asserts the orchestration ends `Terminated` with no pending messages. The later timers can't fire within the test window, so an empty queue proves they were cancelled. Plus minor cleanups (`TimerOrchestration` timer 2s → 1s; ignore `*.lscache` and `test-results/`).

Verified across InMemory / MySQL / PostgreSQL / SQL Server on net8/9/10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
