### PR TITLE
Fix Dependabot glob to freeze base Microsoft.EntityFrameworkCore package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: "Microsoft.EntityFrameworkCore.*"
+      - dependency-name: "Microsoft.EntityFrameworkCore*"
       - dependency-name: "Microsoft.Extensions.*"
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,9 @@
 # Claude Code Instructions
 
+## Language
+
+English for everything: code, commits, PR titles/bodies, issue/PR comments, and docs.
+
 ## Project Overview
 
 This is a .NET library (NuGet packages) extending Azure Durable Task Framework.


### PR DESCRIPTION
## Problem

The current ignore pattern `Microsoft.EntityFrameworkCore.*` (trailing dot) matches only the **suffixed** packages (`.Relational`, `.SqlServer`, …) and **not** the base `Microsoft.EntityFrameworkCore` package.

As a result, Dependabot bumped the base package across a major (`8.0.25 → 9.0.17`) on the **net8.0** TFM while `...Relational` stayed at `8.0.25`. Since EF Core 9 moved `ExecuteDeleteAsync` from `RelationalQueryableExtensions` to `EntityFrameworkQueryableExtensions`, net8.0 ended up with the method in **both** assemblies → `CS0121` (ambiguous call) → broken build (see #107).

## Fix

Dropping the dot (`Microsoft.EntityFrameworkCore*`) also freezes the base package, honoring the rule in `CLAUDE.md`:

> Microsoft.Extensions.\* and Microsoft.EntityFrameworkCore.\* must stay at the **minimum compatible version** for each TFM.

`Microsoft.Extensions.*` needs no change — there is no base `Microsoft.Extensions` package.

With this, Dependabot stops touching EF Core (bumps become manual, per TFM). #107 has been closed; the `dotnet` group will be recreated without the EF Core bumps.

## Also

Adds a `## Language` section to `CLAUDE.md` requiring English for all repository-facing content (code, commits, PRs, issue/PR comments, docs), matching the convention already documented in the cldman and auto-compute repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)